### PR TITLE
Allow jumping to jump_addr if it was requested in the script

### DIFF
--- a/imx_sdp.c
+++ b/imx_sdp.c
@@ -1656,8 +1656,13 @@ int DoIRomDownload(struct sdp_dev *dev, struct sdp_work *curr, int verify)
 		}
 	}
 	if (dev->mode == MODE_HID) if (type == FT_APP) {
-		printf("jumping to 0x%08x\n", header_addr);
-		jump_command.addr = BE32(header_addr);
+		if (curr->jump_addr > 0) {
+			printf("jumping to jump_addr: 0x%08x\n", curr->jump_addr);
+			jump_command.addr = BE32(curr->jump_addr);
+		} else {
+			printf("jumping to header_addr: 0x%08x\n", header_addr);
+			jump_command.addr = BE32(header_addr);
+		}
 		//Any command will initiate jump for mx51, jump address is ignored by mx51
 		retry = 0;
 		for (;;) {

--- a/imx_sdp.c
+++ b/imx_sdp.c
@@ -1633,7 +1633,7 @@ int DoIRomDownload(struct sdp_dev *dev, struct sdp_work *curr, int verify)
 			verify = 2;
 		}
 	}
-	printf("\nloading binary file(%s) to %08x, skip=%x, fsize=%x type=%x\r\n", curr->filename, dladdr, skip, fsize, type);
+	printf("\nloading binary file(%s) to 0x%08x, skip=%x, fsize=%x type=%x\r\n", curr->filename, dladdr, skip, fsize, type);
 	ret = load_file(dev, p, cnt, buf, BUF_SIZE,
 			dladdr, fsize, type, xfile);
 	if (ret < 0)

--- a/imx_sdp.c
+++ b/imx_sdp.c
@@ -289,6 +289,14 @@ void parse_file_work(struct sdp_work *curr, const char *filename, const char *p)
 			curr->load_addr = get_val(&p, 16);
 			p = skip(p,',');
 		}
+		if (strncmp(p, "load_size", 9) == 0) {
+			p += 9;
+			if (strncmp(p, "0x", 2) == 0)
+				curr->load_size = get_val(&p, 16);
+			else
+				curr->load_size = get_val(&p, 10);
+			p = skip(p,',');
+		}
 		if (strncmp(p, "jump", 4) == 0) {
 			p += 4;
 			curr->jump_mode = J_ADDR;


### PR DESCRIPTION
Hi,

I'm preparing support for [Apalis/Ixora for OpenWrt](https://github.com/ynezz/openwrt/tree/wip/imx6-apalis), and in my [recovery script](https://github.com/ynezz/openwrt/blob/0ded6aaa383e239b44085ab73301a5337f5313a4/target/linux/imx6/image/recovery-apalis) I'm flashing SPL, U-boot and rootfs in one go:

```
# openwrt-imx6-apalis-u-boot-with-spl.imx
mmc dev 0 1
mmc write 0x12100000 0x2 0x800

# openwrt-imx6-apalis-squashfs.combined.bin
run set_blkcnt
mmc dev 0 0
mmc write 0x12500000 0 ${blkcnt}
```

For that I'm using following imx_loader script/config:

```
mx6_usb_sdp_uboot
hid,1024,0x10000000,1G,0x00907000,0x31000
openwrt-imx6-apalis-recovery.scr:load 0x12000000
openwrt-imx6-apalis-u-boot-with-spl.imx:load 0x12100000
openwrt-imx6-apalis-squashfs.combined.bin:load 0x12500000,jump 0x12000000
```

Currently it's not possible to load image and jump to the script loaded in different address:

```
openwrt-imx6-apalis-squashfs.combined.bin:load 0x12500000,jump 0x12000000
```

It would simply load rootfs to `0x12500000` but also jump to `0x12500000` and not to the script at `0x12000000`. This PR contains [fix for this issue](https://github.com/toradex/imx_loader/commit/a32e0d073e8a9a1df530a5857f1d2ebe91852a4e), then there's [one cosmetic fixup](https://github.com/toradex/imx_loader/commit/86233600454072e61251a6991a0c7a3c08936315) and [`load_size` command addition](https://github.com/toradex/imx_loader/commit/25d503a60f57aa6a60f5fc8051b0d0e9f1510830), which was helpful for me during development.

Once I'm finished with the support in OpenWrt, I would like to write recovery/flashing procedure and I would like to point to this upstream imx_loader repository and branch on GitHub as I don't want to maintain fork. Could you please consider merging those small changes? Thanks!