### PR TITLE
Fix compilation warning

### DIFF
--- a/imx_usb.c
+++ b/imx_usb.c
@@ -180,7 +180,7 @@ static libusb_device *find_imx_dev(libusb_device **devs, struct mach_id **pp_id,
 		int r = libusb_get_device_descriptor(dev, &desc);
 		if (r < 0) {
 			fprintf(stderr, "failed to get device descriptor");
-			return;
+			return NULL;
 		}
 		p = imx_device(desc.idVendor, desc.idProduct, list);
 		if (p) {


### PR DESCRIPTION
imx_usb.c:183:4: warning: ‘return’ with no value, in function returning non-void
    return;
 